### PR TITLE
Fix compileSdkVersion and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ env:
     - ANDROID_TARGET=android-24
     - ANDROID_ABI=armeabi-v7a
 
-before_install:
-  - yes | sdkmanager "platforms;android-28"
-
 android:
   components:
     - tools
@@ -20,9 +17,9 @@ android:
     - $ANDROID_TARGET
     - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
 
-  licenses:
-    - 'google-gdk-license-.+'
-    - 'android-sdk-preview-license-.+'
+licenses:
+  - 'google-gdk-license-.+'
+  - 'android-sdk-preview-license-.+'
 
 stages:
   - name: lint

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ task printVersionName {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
     buildToolsVersion "29.0.3"
 
     defaultConfig {


### PR DESCRIPTION
### :pushpin: References
* **Issues:** #7 

### :boom: How can it be tested?

I was experiencing errors in the Travis steps because gradle was targeting incorrect API version (I'm using api 28 and was targeting 29)

### :floppy_disk: Requires DB migration?

- [ ] Nope
